### PR TITLE
Pin Python version for heroku

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -256,8 +256,8 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.9,<3.10"
-content-hash = "1d5ccdc56857f83d1f44c4f346be55461f8da7d5c71bd3f8eb115c05d04ff766"
+python-versions = "3.9.7"
+content-hash = "77703c7e8c6d0bafab1719f7c68e96d762df841d335cc28bf455651882a1399d"
 
 [metadata.files]
 apscheduler = [
@@ -371,7 +371,6 @@ numpy = [
     {file = "numpy-1.21.3-cp39-cp39-win_amd64.whl", hash = "sha256:300321e3985c968e3ae7fbda187237b225f3ffe6528395a5b7a5407f73cf093e"},
     {file = "numpy-1.21.3-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98339aa9911853f131de11010f6dd94c8cec254d3d1f7261528c3b3e3219f139"},
     {file = "numpy-1.21.3.zip", hash = "sha256:63571bb7897a584ca3249c86dd01c10bcb5fe4296e3568b2e9c1a55356b6410e"},
-
 ]
 opencv-python = [
     {file = "opencv-python-4.5.4.58.tar.gz", hash = "sha256:48288428f407bacba5f73d460feb4a1ecafe87db3d7cfc0730a49fb32f589bbf"},
@@ -467,7 +466,6 @@ pytz = [
 pytz-deprecation-shim = [
     {file = "pytz_deprecation_shim-0.1.0.post0-py2.py3-none-any.whl", hash = "sha256:8314c9692a636c8eb3bda879b9f119e350e93223ae83e70e80c31675a0fdc1a6"},
     {file = "pytz_deprecation_shim-0.1.0.post0.tar.gz", hash = "sha256:af097bae1b616dde5c5744441e2ddc69e74dfdcb0c263129610d85b87445a59d"},
-
 ]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ishan Manchanda <ishanmanchanda70@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.9.7"
+python = "3.9.7"
 imageio-ffmpeg = "^0.4.5"
 imutils = "^0.5.4"
 numba = "^0.53.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Ishan Manchanda <ishanmanchanda70@gmail.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.9,<3.10"
+python = "^3.9.7"
 imageio-ffmpeg = "^0.4.5"
 imutils = "^0.5.4"
 numba = "^0.53.1"


### PR DESCRIPTION
- Bump pillow from 8.3.1 to 8.3.2
- Bump imageio-ffmpeg from 0.4.4 to 0.4.5
- Bump numpy from 1.21.1 to 1.21.2
- Update README.md
- Bump pytz from 2021.1 to 2021.3
- Switched to spaces for indentation, dependency updates
- git config for TODO bot
- Pin Python version for heroku

## Description

Fixes #

## Changes
  -
  -
  -
